### PR TITLE
Revert "Disable .NET Framework build for Azure-Pipelines CI"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,6 @@ jobs:
         testProjects: |
           [Tt]est/*/*.csproj
           [Tt]est-win/*/*.csproj
-      arguments:    '-p:NoNetFramework=true'
     linuxRuntime:
       common:
         allProjects: |


### PR DESCRIPTION
This reverts commit ccc0820375e2b392d876a165a778d972b5e08184.

Currently blocked by https://github.com/dotnet/sdk/issues/10625